### PR TITLE
Fix Travis CI badge and URL for point to master build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flagbit TableAttributeBundle for Akeneo PIM #
 
-[![Build Status](https://img.shields.io/travis/flagbit/akeneo-table-attribute-bundle.svg?style=flat-square)](https://github.com/flagbit/akeneo-table-attribute-bundle)
+[![Build Status](https://img.shields.io/travis/flagbit/akeneo-table-attribute-bundle/master.svg?style=flat-square)](https://travis-ci.org/flagbit/akeneo-table-attribute-bundle)
 [![Quality Score](https://img.shields.io/scrutinizer/g/flagbit/akeneo-table-attribute-bundle.svg?style=flat-square)](https://scrutinizer-ci.com/g/Flagbit/akeneo-table-attribute-bundle)
 [![Packagist Version](https://img.shields.io/packagist/v/flagbit/table-attribute-bundle.svg?style=flat-square)](https://packagist.org/packages/flagbit/table-attribute-bundle)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)


### PR DESCRIPTION
This fix the Travis CI status badge for pointing to the `master` branch as is the stable one.