### PR TITLE
Prepare 3.0.2 release

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,3 +1,9 @@
+# 3.0.2
+
+## Bug fixes
+
+- Fix BC break introduced by Akeneo core when saving AttributeOptions. [#33][pr33]
+
 # 3.0.1
 
 ## Bug fixes
@@ -13,3 +19,4 @@
 - `Flagbit\Bundle\TableAttributeBundle\Normalizer\StructuredAttributeOptionNormalizer` was deleted. `Flagbit\Bundle\TableAttributeBundle\Normalizer\AttributeOptionNormalizer` is now used for its service.
 
 [pr29]: https://github.com/flagbit/akeneo-table-attribute-bundle/pull/29
+[pr33]: https://github.com/flagbit/akeneo-table-attribute-bundle/pull/33

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,13 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 ## Branch Compatibility
 
-| Branch | Akeneo Compatibility |
-| ------------- |:-------------:|
-| `master` | `>= 3.0.0` |
-| `2.X` | `>= 2.0.5 & < 3.0.0` |
-| `2.0` | `>= 2.0.0 & < 2.0.5` |
-| `1.X` | `>= 1.6.0 & < 2.0.0` |
+Only Akeneo long term support (LTS) versions are supported:
+
+
+| Branch   | Akeneo Compatibility  |
+| -------- |:---------------------:|
+| `master` | `>= 3.2.0`            |
+| `3.0`    | `>= 3.0.21 & < 3.1.0` |
+| `2.X`    | `>= 2.0.5 & < 3.0.0`  |
+| `2.0`    | `>= 2.0.0 & < 2.0.5`  |
+| `1.X`    | `>= 1.6.0 & < 2.0.0`  |

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   ],
   "require": {
     "ext-json": "*",
-    "akeneo/pim-community-dev": "~3.0.21 || ~3.2.0"
+    "akeneo/pim-community-dev": "~3.0.21"
   },
   "require-dev": {
     "phpspec/phpspec": "^5.1",


### PR DESCRIPTION
Branch `3.0` was created for supporting Akeneo Versions `3.0.*` since a BC break was added to `3.1` and `3.2` where `assetic` was removed.