### PR TITLE
Export and import column definition of attribute options

### DIFF
--- a/src/ArrayConverter/FlatToStandard/AttributeOption.php
+++ b/src/ArrayConverter/FlatToStandard/AttributeOption.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Flagbit\Bundle\TableAttributeBundle\ArrayConverter\FlatToStandard;
+
+use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
+
+class AttributeOption implements ArrayConverterInterface
+{
+    /**
+     * @var ArrayConverterInterface
+     */
+    protected $baseArrayConverter;
+
+    public function __construct(ArrayConverterInterface $baseArrayConverter)
+    {
+        $this->baseArrayConverter = $baseArrayConverter;
+    }
+
+    public function convert(array $item, array $options = [])
+    {
+        $convertedItems = [];
+        $baseItem = [];
+
+        foreach ($item as $field => $data) {
+            if (preg_match('/^(constraints|type|type_config\-\w+)$/', $field)) {
+                $convertedItems = $this->convertItem($field, $data, $convertedItems);
+            } else {
+                $baseItem[$field] = $data;
+            }
+        }
+
+        return array_merge(
+            $this->baseArrayConverter->convert($baseItem, $options),
+            $convertedItems
+        );
+    }
+
+    protected function convertItem($field, $data, array $convertedItem)
+    {
+        if (!array_key_exists('type_config', $convertedItem)) {
+            $convertedItem['type_config'] = [];
+        }
+
+        switch ($field) {
+            case 'constraints':
+                $constraints = explode(',', $data);
+                $convertedItem['constraints'] = array_fill_keys($constraints, []);
+                break;
+
+            case 'type_config-is_decimal':
+                if (!empty($data)) {
+                    $convertedItem['type_config']['is_decimal'] = (bool) $data;
+                }
+                break;
+
+            case 'type_config-options_url':
+                if (!empty($data)) {
+                    $convertedItem['type_config']['options_url'] = $data;
+                }
+                break;
+
+            case 'type_config-options':
+                if (!empty($data)) {
+                    $convertedItem['type_config']['options'] = json_decode($data, true);
+                }
+                break;
+
+            default:
+                $convertedItem[$field] = $data;
+                break;
+        }
+
+        return $convertedItem;
+    }
+}

--- a/src/ArrayConverter/StandardToFlat/AttributeOption.php
+++ b/src/ArrayConverter/StandardToFlat/AttributeOption.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Flagbit\Bundle\TableAttributeBundle\ArrayConverter\StandardToFlat;
+
+use Akeneo\Pim\Structure\Component\ArrayConverter\StandardToFlat\AttributeOption as BaseArrayConverter;
+
+class AttributeOption extends BaseArrayConverter
+{
+    protected function convertProperty($property, $data, array $convertedItem, array $options)
+    {
+        switch ($property) {
+            case 'constraints':
+                $convertedItem['constraints'] = implode(',', array_keys($data));
+                break;
+
+            case 'type_config':
+                foreach ($data as $key => $value) {
+                    $convertedItem['type_config-'.$key] = is_array($value) ? json_encode($value) : (string) $value;
+                }
+                break;
+
+            default:
+                $convertedItem = parent::convertProperty($property, $data, $convertedItem, $options);
+                break;
+        }
+
+        return $convertedItem;
+    }
+}

--- a/src/Resources/config/array_converters.xml
+++ b/src/Resources/config/array_converters.xml
@@ -18,5 +18,17 @@
                 <argument>flagbit_catalog_table</argument>
             </argument>
         </service>
+
+        <service id="flagbit_table.array_converter.flat_to_standard.attribute_option"
+                 class="Flagbit\Bundle\TableAttributeBundle\ArrayConverter\FlatToStandard\AttributeOption"
+                 decorates="pim_connector.array_converter.flat_to_standard.attribute_option"
+                 decoration-inner-name="pim_connector.array_converter.flat_to_standard.attribute_option_base">
+            <argument type="service" id="pim_connector.array_converter.flat_to_standard.attribute_option_base"/>
+        </service>
+
+        <service id="flagbit_table.array_converter.standard_to_flat.attribute_option"
+                 class="Flagbit\Bundle\TableAttributeBundle\ArrayConverter\StandardToFlat\AttributeOption"
+                 decorates="pim_connector.array_converter.standard_to_flat.attribute_option">
+        </service>
     </services>
 </container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -27,6 +27,14 @@
             <tag name="pim_internal_api_serializer.normalizer" priority="200"/>
         </service>
 
+        <service id="flagbit_table_attribute.catalog.normalizer.standard.attribute_option"
+                 class="Flagbit\Bundle\TableAttributeBundle\Normalizer\AttributeOptionNormalizer"
+                 decorates="pim_catalog.normalizer.standard.attribute_option"
+                 decoration-inner-name="pim_catalog.normalizer.standard.attribute_option_base">
+            <argument type="service" id="pim_catalog.normalizer.standard.attribute_option_base"/>
+            <tag name="pim_standard_format_serializer.normalizer" priority="90"/>
+        </service>
+
         <service id="flagbit_table_attribute.form.extension.attribute_option" class="%flagbit_table_attribute.form.extension.attribute_option.class%">
             <tag name="form.type_extension" extended_type="Akeneo\Pim\Structure\Bundle\Form\Type\AttributeOptionType"
                  alias="pim_enrich_attribute_option" />

--- a/src/Resources/config/updaters.xml
+++ b/src/Resources/config/updaters.xml
@@ -11,5 +11,11 @@
             </argument>
             <tag name="pim_catalog.updater.setter"/>
         </service>
+
+        <service id="flagbit_table.updater.attribute_option"
+                 class="Flagbit\Bundle\TableAttributeBundle\Updater\AttributeOptionUpdater"
+                 decorates="pim_catalog.updater.attribute_option">
+            <argument type="service" id="pim_catalog.repository.attribute"/>
+        </service>
     </services>
 </container>

--- a/src/Updater/AttributeOptionUpdater.php
+++ b/src/Updater/AttributeOptionUpdater.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Flagbit\Bundle\TableAttributeBundle\Updater;
+
+use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
+use Akeneo\Pim\Structure\Component\Updater\AttributeOptionUpdater as BaseUpdater;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Flagbit\Bundle\TableAttributeBundle\Entity\AttributeOption;
+
+class AttributeOptionUpdater extends BaseUpdater
+{
+    protected function validateDataType($field, $data)
+    {
+        if (!in_array($field, ['type', 'type_config', 'constraints'])) {
+            return parent::validateDataType($field, $data);
+        }
+
+        switch ($field) {
+            case 'type':
+                $availableTypes = ['select', 'select_from_url', 'text', 'number'];
+                if (!in_array($data, $availableTypes)) {
+                    InvalidPropertyException::dataExpected('type', implode(', ', $availableTypes), static::class);
+                }
+                break;
+
+            case 'type_config':
+                if (!is_array($data)) {
+                    throw InvalidPropertyTypeException::arrayExpected($field, static::class, $data);
+                }
+
+                foreach ($data as $key => $value) {
+                    $this->validateTypeConfig($key, $value);
+                }
+                break;
+
+            case 'constraints':
+                if (!is_array($data)) {
+                    throw InvalidPropertyTypeException::arrayExpected($field, static::class, $data);
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    protected function validateTypeConfig($key, $value)
+    {
+        switch ($key) {
+            case 'is_decimal':
+                if (!is_bool($value)) {
+                    InvalidPropertyTypeException::booleanExpected('type_config-is_decimal', static::class, $value);
+                }
+                break;
+
+            case 'options':
+                if (!is_array($value)) {
+                    throw InvalidPropertyTypeException::arrayExpected('type_config-options', static::class, $value);
+                }
+                break;
+
+            case 'options_url':
+                if (!is_string($value)) {
+                    InvalidPropertyTypeException::stringExpected('type_config-options_url', static::class, $value);
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    protected function setData(AttributeOptionInterface $attributeOption, $field, $data)
+    {
+        parent::setData($attributeOption, $field, $data);
+
+        if ($attributeOption instanceof AttributeOption && $attributeOption->isTableAttribute()) {
+            if ('type' === $field) {
+                $attributeOption->setType($data);
+            }
+
+            if ('type_config' === $field) {
+                $attributeOption->setTypeConfig($data);
+            }
+
+            if ('constraints' === $field) {
+                $attributeOption->setConstraints($data);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add decorators for Akeneo services to enhance the standard CSV and XLSX batch jobs.

This will also allow to init table attributes and their column definition via fixtures.

Relates to and fixes issue #43 