### PR TITLE
Fix of select form extension in product export filters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,9 @@ jobs:
           php-version: "${{ matrix.php-versions }}"
           extensions: "intl, xdebug, imagick, apcu"
 
-      # Install / Prepare
       - name: "Install PHP dependencies"
         run: "composer install --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress"
 
-      # CI
       - name: "Linting"
         run: "vendor/bin/phplint ./src"
       - name: "Code Sniffer"
@@ -56,10 +54,10 @@ jobs:
       - name: "Install PHP dependencies"
         run: "composer install --prefer-dist --no-interaction --optimize-autoloader --no-suggest --no-progress"
 
-#      - name: "yarn install"
-#        uses: "borales/actions-yarn@v2.0.0"
-#        with:
-#          cmd: "install"
+      - name: "yarn install"
+        uses: "borales/actions-yarn@v2.0.0"
+        with:
+          cmd: "install"
 
-#      - name: "Check for obsolete ts exports"
-#        run: "yarn run tests"
+      - name: "Run frontend tests"
+        run: "yarn run test"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /composer.lock
 /coverage
 /tests/Kernel/var
+/yarn.lock
+/tests/public/js/extensions.json
+/.phpunit.result.cache
+/node_modules

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,0 +1,9 @@
+# 4.0.1
+
+## Bug fixes
+
+- Fix of select form extension in product export filters [#54][pr54]
+
+# 4.0.0
+
+[pr54]: https://github.com/flagbit/akeneo-table-attribute-bundle/pull/54

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    verbose: true,
+    rootDir: './',
+    testURL: 'http://localhost/',
+    testMatch: ['**/jest/**/*.test.js'],
+};

--- a/jest/integration/formextensions.test.js
+++ b/jest/integration/formextensions.test.js
@@ -1,0 +1,22 @@
+describe('Form Extensions', function() {
+    it('table attribute overrides akeneo-attribute-select-filter', function() {
+        const formExtensions = require('../../tests/public/js/extensions.json');
+
+        const expected = {
+            module: 'pim/filter/attribute/select',
+            parent: null,
+            targetZone: 'self',
+            zones: [],
+            aclResourceId: null,
+            config: {
+                url: 'pim_ui_ajaxentity_list',
+                entityClass: 'Flagbit\\Bundle\\TableAttributeBundle\\Entity\\AttributeOption',
+                operators: [ 'IN', 'EMPTY', 'NOT EMPTY' ]
+            },
+            position: 100,
+            code: 'akeneo-attribute-select-filter'
+        };
+
+        expect(formExtensions.extensions).toContainEqual(expected);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pim-enterprise-standard",
+  "description": "Akeneo PIM Enterprise Standard Edition",
+  "homepage": "http://www.akeneo.com",
+  "private": true,
+  "config": {
+    "source": "vendor/akeneo/pim-community-dev",
+    "styles": "vendor/akeneo/pim-community-dev/frontend/build/compile-less.js"
+  },
+  "scripts": {
+    "update-extensions": "cd tests && node ../vendor/akeneo/pim-community-dev/frontend/build/update-extensions.js",
+    "test": "yarn update-extensions && jest --no-cache --config jest.config.js"
+  },
+  "workspaces": [
+    "vendor/akeneo/pim-community-dev",
+    "vendor/akeneo/pim-community-dev/src/Akeneo/Connectivity/Connection/front"
+  ]
+}

--- a/src/Resources/config/form_extensions.yml
+++ b/src/Resources/config/form_extensions.yml
@@ -2,11 +2,5 @@ attribute_fields:
     flagbit-table-field: flagbit/table-field
 extensions:
     akeneo-attribute-select-filter:
-        module: pim/filter/attribute/select
         config:
-            url: pim_ui_ajaxentity_list
-            entityClass: "%pim_catalog.entity.attribute_option.class%"
-            operators:
-                - IN
-                - EMPTY
-                - NOT EMPTY
+            entityClass: Flagbit\Bundle\TableAttributeBundle\Entity\AttributeOption

--- a/tests/Pim/TagsAndServiceOverridesTest.php
+++ b/tests/Pim/TagsAndServiceOverridesTest.php
@@ -14,10 +14,9 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute as Pu
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Flagbit\Bundle\TableAttributeBundle\AttributeType\TableType;
-use Flagbit\Bundle\TableAttributeBundle\Component\Product\Factory\Value\TableValueFactory;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-class PimTest extends KernelTestCase
+class TagsAndServiceOverridesTest extends KernelTestCase
 {
 
     public function testFlatToStandardConverterRegisters()

--- a/tests/public/js/require-paths.js
+++ b/tests/public/js/require-paths.js
@@ -1,0 +1,3 @@
+module.exports = [
+"../vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/UIBundle",
+"../src"]


### PR DESCRIPTION
Because properties seem to be not allowed in form extension configs anymore, the property name was considered the class name in Akeneo 4. This PR introduces a fix by using the FQCN in the overridden extension as a fix.

To prevent further regressions in the future a frontend test env was introduced to handle this frontend related issue. It's currently jest, but it might change in the future.