### PR TITLE
Save initial empty select fields

### DIFF
--- a/src/Resources/public/js/product/field/table-field.js
+++ b/src/Resources/public/js/product/field/table-field.js
@@ -111,7 +111,6 @@ define([
                 };
             },
             createColumnFunctions: function(item) {
-                // TODO Move this mapping to Symfony tags for every type to make this extendable
                 var fieldTemplate;
                 var parser = function (td) {
                     return $('input', td).val();
@@ -147,6 +146,11 @@ define([
 
                         parser = function (td) {
                             var option = $('input', td).select2('data');
+
+                            if (Array.isArray(option)) {
+                                return null;
+                            }
+
                             return option.id;
                         };
 
@@ -174,6 +178,11 @@ define([
 
                         parser = function (td) {
                             var option = $('input', td).select2('data');
+
+                            if (Array.isArray(option)) {
+                                return null;
+                            }
+
                             return option.id;
                         };
 


### PR DESCRIPTION
Handles #63

Empty select values need to be handled by the user with an option representing empty values, but since there is an initial empty value on row creation, this PR handles just the prevention of throwing an error.